### PR TITLE
support core adafruit_bus_device

### DIFF
--- a/adafruit_debug_i2c.py
+++ b/adafruit_debug_i2c.py
@@ -71,6 +71,8 @@ class DebugI2C:
         if hasattr(self._i2c, "writeto_then_readfrom"):
             self.writeto_then_readfrom = self._writeto_then_readfrom
 
+        self.probe = self._i2c.probe
+
     def __enter__(self) -> I2C:
         """
         No-op used in Context Managers.


### PR DESCRIPTION
Resolves: https://github.com/adafruit/circuitpython/issues/10890

Fixes support for core implementation of adafruit_bus_device by adding `DebugI2C.probe()` function that defers to `I2C.probe()`

 