### PR TITLE
fix out_end default value

### DIFF
--- a/adafruit_debug_i2c.py
+++ b/adafruit_debug_i2c.py
@@ -190,6 +190,8 @@ class DebugI2C:
         print(f"\tI2CWRITE @ {hex(address)} ::", out_buffer_str)
         if in_end is None:
             in_end = len(buffer_in)
+        if out_end is None:
+            out_end = len(buffer_out)
         self._i2c.writeto_then_readfrom(
             address,
             buffer_out,


### PR DESCRIPTION
This fixes an issue when the DebugI2C instance is used with the newer register_accessor layer inside of adafruit_register. 

This is the traceback from that issue:
```
	I2CWRITE @ 0x47 :: 0x7e
Traceback (most recent call last):
  File "code.py", line 10, in <module>
  File "adafruit_bmp5xx.py", line 248, in over_i2c
  File "adafruit_bmp5xx.py", line 260, in __init__
  File "adafruit_bmp5xx.py", line 301, in reset
  File "adafruit_register/register_bits.py", line 79, in __set__
  File "adafruit_register/register_accessor.py", line 145, in read_register
  File "/lib/adafruit_debug_i2c.py", line 196, in _writeto_then_readfrom
TypeError: can't convert NoneType to int
```

I found that `out_end` argument was `None`. The docstrings say that it will default to the length of buffer_out but that behavior was not implemented before so this PR adds it.
```
:param int out_end: End of the slice; this index is not included. Defaults to
     ``len(buffer_out)``
```

This this change the behavior matches docstring and the library seems to work successfully with register_accessor based drivers.